### PR TITLE
Allow failures and return the hash along with the number

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,31 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm run build --if-present
+    - run: npm test
+      env:
+        CI: true

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ out-of-date node).
 For use in front-end dapps, this smart contract is intended to be used with
 [Multicall.js](https://github.com/makerdao/multicall.js).
 
-### Contract Addresses
+### Contract Addresses for Multicall V1
 | Chain   | Address |
 | ------- | ------- |
 | Mainnet | [0xeefba1e63905ef1d7acba5a8513c70307c1ce441](https://etherscan.io/address/0xeefba1e63905ef1d7acba5a8513c70307c1ce441#contracts) |

--- a/src/Multicall.sol
+++ b/src/Multicall.sol
@@ -17,9 +17,12 @@ contract Multicall2 {
         bytes returnData;
     }
 
-    // Multiple calls in one! (Deprecated because it lacks blockHash)
+    // Multiple calls in one! (Replaced by block_and_aggregate and try_block_and_aggregate)
     // Reverts if any call fails.
-    function aggregate(Call[] memory calls) public returns (uint256 blockNumber, bytes[] memory returnData) {
+    function aggregate(Call[] memory calls)
+        public
+        returns (uint256 blockNumber, bytes[] memory returnData)
+    {
         blockNumber = block.number;
         returnData = new bytes[](calls.length);
         for(uint256 i = 0; i < calls.length; i++) {
@@ -35,26 +38,35 @@ contract Multicall2 {
     // Reverts if any call fails.
     // Use when you are querying the latest block and need all the calls to succeed.
     // Check the hash to protect yourself from re-orgs!
-    function block_and_aggregate(Call[] memory calls) public returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData) {
-        blockNumber = block.number;
-        blockHash = blockhash(blockNumber);
-        returnData = try_aggregate(true, calls);
+    function block_and_aggregate(Call[] memory calls)
+        public
+        returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData)
+    {
+        (blockNumber, blockHash, returnData) = try_block_and_aggregate(true, calls);
     }
 
     // Multiple calls in one!
-    // This does *not* revert if a call fails. Check the success bool before using the returnData.
-    // Use when you are querying the latest block and only need some of the calls to succeed.
+    // If `require_success == true`, this revert if a call fails.
+    // If `require_success == false`, failures are allowed. Check the success bool before using the returnData.
+    // Use when you are querying the latest block.
     // Returns the block and hash so you can protect yourself from re-orgs.
-    function try_block_and_aggregate(Call[] memory calls) public returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData) {
+    function try_block_and_aggregate(bool require_success, Call[] memory calls)
+        public
+        returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData)
+    {
         blockNumber = block.number;
         blockHash = blockhash(blockNumber);
-        returnData = try_aggregate(false, calls);
+        returnData = try_aggregate(require_success, calls);
     }
 
     // Multiple calls in one!
-    // This does *not* revert if a call fails. Check the success bool before using the returnData.
+    // If `require_success == true`, this revert if a call fails.
+    // If `require_success == false`, failures are allowed. Check the success bool before using the returnData.
     // Use when you are querying a specific block number and hash.
-    function try_aggregate(bool require_success, Call[] memory calls) public returns (Result[] memory returnData) {
+    function try_aggregate(bool require_success, Call[] memory calls)
+        public
+        returns (Result[] memory returnData)
+    {
         returnData = new Result[](calls.length);
 
         for(uint256 i = 0; i < calls.length; i++) {

--- a/src/Multicall.sol
+++ b/src/Multicall.sol
@@ -12,33 +12,13 @@ contract Multicall2 {
         address target;
         bytes callData;
     }
-
     struct Result {
         bool success;
-        bytes ret;
+        bytes returnData;
     }
 
-    // public functions
-    function try_block_and_aggregate(Call[] memory calls) public returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData) {
-        blockNumber = block.number;
-        blockHash = blockhash(blockNumber);
-        returnData = try_aggregate(calls);
-    }
-    function try_aggregate(Call[] memory calls) public returns (Result[] memory returnData) {
-        returnData = new Result[](calls.length);
-
-        for(uint256 i = 0; i < calls.length; i++) {
-            // we use low level calls to intionally allow calling arbitrary functions.
-            // solium-disable-next-line security/no-low-level-calls
-            (bool success, bytes memory ret) = calls[i].target.call(calls[i].callData);
-
-            // TODO? optionally require(success, "Multicall2 aggregate: call failed");
-
-            returnData[i] = Result(success, ret);
-        }
-    }
-
-    // old aggregate method. requires all calls to succeed
+    // Multiple calls in one! (Deprecated because it lacks blockHash)
+    // Reverts if any call fails.
     function aggregate(Call[] memory calls) public returns (uint256 blockNumber, bytes[] memory returnData) {
         blockNumber = block.number;
         returnData = new bytes[](calls.length);
@@ -50,6 +30,47 @@ contract Multicall2 {
             returnData[i] = ret;
         }
     }
+
+    // Multiple calls in one!
+    // Reverts if any call fails.
+    // Use when you are querying the latest block and need all the calls to succeed.
+    // Check the hash to protect yourself from re-orgs!
+    function block_and_aggregate(Call[] memory calls) public returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData) {
+        blockNumber = block.number;
+        blockHash = blockhash(blockNumber);
+        returnData = try_aggregate(true, calls);
+    }
+
+    // Multiple calls in one!
+    // This does *not* revert if a call fails. Check the success bool before using the returnData.
+    // Use when you are querying the latest block and only need some of the calls to succeed.
+    // Returns the block and hash so you can protect yourself from re-orgs.
+    function try_block_and_aggregate(Call[] memory calls) public returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData) {
+        blockNumber = block.number;
+        blockHash = blockhash(blockNumber);
+        returnData = try_aggregate(false, calls);
+    }
+
+    // Multiple calls in one!
+    // This does *not* revert if a call fails. Check the success bool before using the returnData.
+    // Use when you are querying a specific block number and hash.
+    function try_aggregate(bool require_success, Call[] memory calls) public returns (Result[] memory returnData) {
+        returnData = new Result[](calls.length);
+
+        for(uint256 i = 0; i < calls.length; i++) {
+            // we use low level calls to intionally allow calling arbitrary functions.
+            // solium-disable-next-line security/no-low-level-calls
+            (bool success, bytes memory ret) = calls[i].target.call(calls[i].callData);
+
+            if (require_success) {
+                // TODO: give a more useful message about specifically which call failed
+                require(success, "Multicall2 aggregate: call failed");
+            }
+
+            returnData[i] = Result(success, ret);
+        }
+    }
+
 
     // Helper functions
     function getBlockHash() public view returns (bytes32 blockHash) {

--- a/src/Multicall.sol
+++ b/src/Multicall.sol
@@ -38,7 +38,7 @@ contract Multicall2 {
         }
     }
 
-    // old aggregate method. requires all calls to succeed. use block_and_aggregate instead
+    // old aggregate method. requires all calls to succeed
     function aggregate(Call[] memory calls) public returns (uint256 blockNumber, bytes[] memory returnData) {
         blockNumber = block.number;
         returnData = new bytes[](calls.length);

--- a/src/Multicall.sol
+++ b/src/Multicall.sol
@@ -68,6 +68,7 @@ contract Multicall2 {
         gaslimit = block.gaslimit;
     }
     function getCurrentBlockTimestamp() public view returns (uint256 timestamp) {
+        // solium-disable-next-line security/no-block-members
         timestamp = block.timestamp;
     }
     function getEthBalance(address addr) public view returns (uint256 balance) {


### PR DESCRIPTION
Sometimes I'm aggregating calls and I expect some failures. This lets me aggregate them.

Returning the block hash helps me in the event of a re-org.