### PR TITLE
Allow calls to fail and return the block hash.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ out-of-date node).
 For use in front-end dapps, this smart contract is intended to be used with
 [Multicall.js](https://github.com/makerdao/multicall.js).
 
-### Contract Addresses
+### Contract Addresses for Multicall V1
 | Chain   | Address |
 | ------- | ------- |
 | Mainnet | [0xeefba1e63905ef1d7acba5a8513c70307c1ce441](https://etherscan.io/address/0xeefba1e63905ef1d7acba5a8513c70307c1ce441#contracts) |

--- a/src/Multicall.sol
+++ b/src/Multicall.sol
@@ -1,37 +1,98 @@
 pragma solidity >=0.5.0;
 pragma experimental ABIEncoderV2;
 
-/// @title Multicall - Aggregate results from multiple read-only function calls
+/// @title Multicall2 - Aggregate results from multiple read-only function calls. Allow failures
 /// @author Michael Elliot <mike@makerdao.com>
 /// @author Joshua Levine <joshua@makerdao.com>
 /// @author Nick Johnson <arachnid@notdot.net>
+/// @author Bryan Stitt <bryan@satoshiandkin.com>
 
-contract Multicall {
+contract Multicall2 {
     struct Call {
         address target;
         bytes callData;
     }
-    function aggregate(Call[] memory calls) public returns (uint256 blockNumber, bytes[] memory returnData) {
+    struct Result {
+        bool success;
+        bytes returnData;
+    }
+
+    // Multiple calls in one! (Replaced by block_and_aggregate and try_block_and_aggregate)
+    // Reverts if any call fails.
+    function aggregate(Call[] memory calls)
+        public
+        returns (uint256 blockNumber, bytes[] memory returnData)
+    {
         blockNumber = block.number;
         returnData = new bytes[](calls.length);
         for(uint256 i = 0; i < calls.length; i++) {
+            // we use low level calls to intionally allow calling arbitrary functions.
+            // solium-disable-next-line security/no-low-level-calls
             (bool success, bytes memory ret) = calls[i].target.call(calls[i].callData);
-            require(success);
+            require(success, "Multicall2 aggregate: call failed");
             returnData[i] = ret;
         }
     }
-    // Helper functions
-    function getEthBalance(address addr) public view returns (uint256 balance) {
-        balance = addr.balance;
+
+    // Multiple calls in one!
+    // Reverts if any call fails.
+    // Use when you are querying the latest block and need all the calls to succeed.
+    // Check the hash to protect yourself from re-orgs!
+    function block_and_aggregate(Call[] memory calls)
+        public
+        returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData)
+    {
+        (blockNumber, blockHash, returnData) = try_block_and_aggregate(true, calls);
     }
-    function getBlockHash(uint256 blockNumber) public view returns (bytes32 blockHash) {
+
+    // Multiple calls in one!
+    // If `require_success == true`, this revert if a call fails.
+    // If `require_success == false`, failures are allowed. Check the success bool before using the returnData.
+    // Use when you are querying the latest block.
+    // Returns the block and hash so you can protect yourself from re-orgs.
+    function try_block_and_aggregate(bool require_success, Call[] memory calls)
+        public
+        returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData)
+    {
+        blockNumber = block.number;
         blockHash = blockhash(blockNumber);
+        returnData = try_aggregate(require_success, calls);
     }
-    function getLastBlockHash() public view returns (bytes32 blockHash) {
-        blockHash = blockhash(block.number - 1);
+
+    // Multiple calls in one!
+    // If `require_success == true`, this revert if a call fails.
+    // If `require_success == false`, failures are allowed. Check the success bool before using the returnData.
+    // Use when you are querying a specific block number and hash.
+    function try_aggregate(bool require_success, Call[] memory calls)
+        public
+        returns (Result[] memory returnData)
+    {
+        returnData = new Result[](calls.length);
+
+        for(uint256 i = 0; i < calls.length; i++) {
+            // we use low level calls to intionally allow calling arbitrary functions.
+            // solium-disable-next-line security/no-low-level-calls
+            (bool success, bytes memory ret) = calls[i].target.call(calls[i].callData);
+
+            if (require_success) {
+                // TODO: give a more useful message about specifically which call failed
+                require(success, "Multicall2 aggregate: call failed");
+            }
+
+            returnData[i] = Result(success, ret);
+        }
     }
-    function getCurrentBlockTimestamp() public view returns (uint256 timestamp) {
-        timestamp = block.timestamp;
+
+
+    // Helper functions
+    function getBlockHash() public view returns (bytes32 blockHash) {
+        blockHash = blockhash(block.number);
+    }
+    function getBlockNumber() public view returns (uint256 blockNumber) {
+        blockNumber = block.number;
+    }
+    function getCurrentBlockCoinbase() public view returns (address coinbase) {
+        coinbase = block.coinbase;
     }
     function getCurrentBlockDifficulty() public view returns (uint256 difficulty) {
         difficulty = block.difficulty;
@@ -39,7 +100,14 @@ contract Multicall {
     function getCurrentBlockGasLimit() public view returns (uint256 gaslimit) {
         gaslimit = block.gaslimit;
     }
-    function getCurrentBlockCoinbase() public view returns (address coinbase) {
-        coinbase = block.coinbase;
+    function getCurrentBlockTimestamp() public view returns (uint256 timestamp) {
+        // solium-disable-next-line security/no-block-members
+        timestamp = block.timestamp;
+    }
+    function getEthBalance(address addr) public view returns (uint256 balance) {
+        balance = addr.balance;
+    }
+    function getLastBlockHash() public view returns (bytes32 blockHash) {
+        blockHash = blockhash(block.number - 1);
     }
 }


### PR DESCRIPTION
Sometimes I'm aggregating calls and I expect some failures. This lets me aggregate them.

Returning the block hash helps me in the event of a re-org.