### PR TITLE
Aggregate without revert

### DIFF
--- a/src/Multicall.sol
+++ b/src/Multicall.sol
@@ -20,6 +20,15 @@ contract Multicall {
             returnData[i] = ret;
         }
     }
+    function aggregateWithoutRevert(Call[] memory calls) public returns (uint256 blockNumber, bytes[] memory returnData) {
+        blockNumber = block.number;
+        returnData = new bytes[](calls.length);
+        for(uint256 i = 0; i < calls.length; i++) {
+            (bool success, bytes memory ret) = calls[i].target.call(calls[i].callData);
+            if(success)
+                returnData[i] = ret;
+        }
+    }
     // Helper functions
     function getEthBalance(address addr) public view returns (uint256 balance) {
         balance = addr.balance;


### PR DESCRIPTION
Whih the method aggregateWithoutRevert, if one or more of the calls has a revert, the return of this call/s is '0x' then it can be treated and not send all the calls again