### PR TITLE
Add BSC multicall contract address

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ For use in front-end dapps, this smart contract is intended to be used with
 | Görli   | [0x77dca2c955b15e9de4dbbcf1246b4b85b651e50e](https://goerli.etherscan.io/address/0x77dca2c955b15e9de4dbbcf1246b4b85b651e50e#contracts) |
 | Ropsten | [0x53c43764255c17bd724f74c4ef150724ac50a3ed](https://ropsten.etherscan.io/address/0x53c43764255c17bd724f74c4ef150724ac50a3ed#code) |
 | xDai    | [0xb5b692a88bdfc81ca69dcb1d924f59f0413a602a](https://blockscout.com/poa/dai/address/0xb5b692a88bdfc81ca69dcb1d924f59f0413a602a) |
+| BSC    | [0x41263cba59eb80dc200f3e2544eda4ed6a90e76c](https://bscscan.com/address/0x41263cba59eb80dc200f3e2544eda4ed6a90e76c) |


### PR DESCRIPTION
I personally needed multicall on the BSC, but since more and more projects are launching on this network, other developers will probably need it.

The multicall contract is verified, here's the link - [https://bscscan.com/address/0x41263cba59eb80dc200f3e2544eda4ed6a90e76c#code](https://bscscan.com/address/0x41263cba59eb80dc200f3e2544eda4ed6a90e76c#code).