### PR TITLE
Add SPDX-License-Identifier: MIT to Multicall.sol

### DIFF
--- a/src/Multicall.sol
+++ b/src/Multicall.sol
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+
+
 pragma solidity >=0.5.0;
 pragma experimental ABIEncoderV2;
 


### PR DESCRIPTION
Stops more recent versions of solc complaining about this:
```
Warning: SPDX license identifier not provided in source file. Before publishing, consider adding a comment containing "SPDX-License-Identifier: <SPDX-License>" to each source file.
```