### PR TITLE
Avalanche FUJI Testnet  deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ The following addresses have been submitted by external contributors and have no
 | RSK Testnet   | [0x9e469e1fc7fb4c5d17897b68eaf1afc9df39f103](https://explorer.testnet.rsk.co/address/0x9e469e1fc7fb4c5d17897b68eaf1afc9df39f103) |
 | BSC Mainnet   | [0x41263cba59eb80dc200f3e2544eda4ed6a90e76c](https://bscscan.com/address/0x41263cba59eb80dc200f3e2544eda4ed6a90e76c) |
 | BSC Testnet   | [0xae11C5B5f29A6a25e955F0CB8ddCc416f522AF5C](https://testnet.bscscan.com/address/0xae11c5b5f29a6a25e955f0cb8ddcc416f522af5c) |
+| Avalanche FUJI Testnet   | [0xccc75e78Dce6A20bCCa3a30deB23Cb4D23df993a](https://cchain.explorer.avax-test.network/address/0xccc75e78Dce6A20bCCa3a30deB23Cb4D23df993a/contracts) |


### PR DESCRIPTION
Hello guys,
We have deployed the Multicall.sol contract in the Avalanche FUJI testnet.

We have also Verified the code, which is available at https://cchain.explorer.avax-test.network/address/0xccc75e78Dce6A20bCCa3a30deB23Cb4D23df993a/contracts

This commit adds the Multicall contract address to the README.md

We will soon also deploy it to the Avalanche mainnet.

Cheers!