### PR TITLE
Add SPDX License Identifier to Multicall2.sol

### DIFF
--- a/src/Multicall2.sol
+++ b/src/Multicall2.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.5.0;
 pragma experimental ABIEncoderV2;
 


### PR DESCRIPTION
It fixes the compiler warning `license identifier not provided in source file` and is overall good practice to add the license identifier on a per-file basis as in the software industry no license specified defaults to all rights reserved, which could potentially prevent anyone to have the rights to deploy the individual Multicall2.sol. Though, this is technically not necessary in the particular case of MIT and Unlicense licenses.