### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DEPRECATED
 
-_This repository is no longer maintained. An active version can be found at https://github.com/mds1/multicall. Note that this is an external repository not maintained by the MakerDAO Protocol Engineering Core Unit._
+_This repository is no longer maintained. An active version can be found at https://github.com/mds1/multicall. Note that this is an external repository not maintained by any entity funded or directed by MakerDAO governance._
 
 # Multicall <img width="100" align="right" alt="Multicall" src="https://user-images.githubusercontent.com/304108/55666937-320cb180-5888-11e9-907b-48ba66150523.png" />
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# DEPRECATED
+
+_This repository is no longer maintained. An active version can be found at https://github.com/mds1/multicall._
+
 # Multicall <img width="100" align="right" alt="Multicall" src="https://user-images.githubusercontent.com/304108/55666937-320cb180-5888-11e9-907b-48ba66150523.png" />
 
 Multicall aggregates results from multiple contract constant function calls.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DEPRECATED
 
-_This repository is no longer maintained. An active version can be found at https://github.com/mds1/multicall._
+_This repository is no longer maintained. An active version can be found at https://github.com/mds1/multicall. Note that this is an external repository not maintained by the MakerDAO Protocol Engineering Core Unit._
 
 # Multicall <img width="100" align="right" alt="Multicall" src="https://user-images.githubusercontent.com/304108/55666937-320cb180-5888-11e9-907b-48ba66150523.png" />
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DEPRECATED
 
-_This repository is no longer maintained. An active version can be found at https://github.com/mds1/multicall. Note that this is an external repository not maintained by any entity funded or directed by MakerDAO governance._
+_This repository is no longer maintained. An active fork can be found at https://github.com/mds1/multicall. Note that this is an external repository not maintained by any entity funded or directed by MakerDAO governance._
 
 # Multicall <img width="100" align="right" alt="Multicall" src="https://user-images.githubusercontent.com/304108/55666937-320cb180-5888-11e9-907b-48ba66150523.png" />
 


### PR DESCRIPTION
This repository has been great, and I've relied on these Multicall contracts many times over the past few years. However, it appears this repo is no longer be maintained, as there are open issues and pull requests that have not been addressed for over a year.

As a result we've written an updated Multicall contract that is backwards-compatible with these versions, deployed it at the same address on 35 chains, and continue to perform new deploys as requested for other chains. This repo can be found at https://github.com/mds1/multicall.

New issues and PRs are still opened on this repository as it's easier to find than the above fork, so to help users I think it would be great to:
- Mark this repo deprecated in the README and point to the updated fork
- Prepend `[DEPRECATED]` to the repo description 
- Optionally, archive the repo so it's read only.